### PR TITLE
koboldai: python package

### DIFF
--- a/projects/koboldai/package.nix
+++ b/projects/koboldai/package.nix
@@ -1,17 +1,14 @@
 { aipython3
 , lib
 , src
-, wsl ? false
 , fetchFromGitHub
-, writeShellScriptBin
-, runCommand
-, tmpDir ? "/tmp/nix-koboldai"
+, lndir
 , stateDir ? "$HOME/.koboldai/state"
 }:
 let
-  overrides = {
-    transformers = aipython3.transformers.overrideAttrs (old: rec {
-       propagatedBuildInputs = old.propagatedBuildInputs ++ [ aipython3.huggingface-hub ];
+  pythonPackages = aipython3.overrideScope (final: prev: {
+    transformers = prev.transformers.overrideAttrs (old: rec {
+       propagatedBuildInputs = old.propagatedBuildInputs ++ [ final.huggingface-hub ];
        pname = "transformers";
        version = "4.24.0";
        src = fetchFromGitHub {
@@ -21,7 +18,7 @@ let
          hash = "sha256-aGtTey+QK12URZcGNaRAlcaOphON4ViZOGdigtXU1g0=";
        };
     });
-    bleach = aipython3.bleach.overrideAttrs (old: rec {
+    bleach = prev.bleach.overrideAttrs (old: rec {
        pname = "bleach";
        version = "4.1.0";
        src = fetchFromGitHub {
@@ -31,42 +28,70 @@ let
          hash = "sha256-YuvH8FvZBqSYRt7ScKfuTZMsljJQlhFR+3tg7kABF0Y=";
        };
     });
-  };
+  });
+in pythonPackages.buildPythonPackage {
+  pname = "koboldai";
+  version = if src ? lastModifiedDate
+    then builtins.substring 0 8 src.lastModifiedDate
+    else "0";
+
   # The original kobold-ai program wants to write models settings and user
   # scripts to the current working directory, but tries to write to the
   # /nix/store erroneously due to mismanagement of the current working
-  # directory in its source code. The patching below replicates the original
-  # functionality of the program by making symlinks in the source code
-  # directory that point to ${tmpDir}
+  # directory in its source code.
   #
-  # The wrapper script we have made for the program will then create another
-  # symlink that points to ${stateDir}, ultimately the default symlink trail
-  # looks like the following
-  #
-  # /nix/store/kobold-ai/models -> /tmp/nix-koboldai -> ~/.koboldai/state
-  patchedSrc = runCommand "koboldAi-patchedSrc" {} ''
-    cp -r --no-preserve=mode ${src} ./src
-    cd src
-    rm -rf models settings userscripts
-    cd -
-    substituteInPlace ./src/aiserver.py \
-      --replace 'os.system("")' 'STATE_DIR = os.path.expandvars("${stateDir}")' \
-      --replace 'cache_dir="cache"' "cache_dir=os.path.join(STATE_DIR, 'cache')" \
-      --replace 'shutil.rmtree("cache/")' 'shutil.rmtree(os.path.join(STATE_DIR, "cache"))' \
-      --replace "app.config['SESSION_TYPE'] = 'filesystem'" "app.config['SESSION_TYPE'] = 'memcached'"
+  # The wrapper script we have made for the program will initialize ${stateDir}
+  # as an appropriate working directory to run from.
 
-    # https://stackoverflow.com/questions/59433832/runtimeerror-only-tensors-of-floating-point-dtype-can-require-gradients
-    # Typo in casing by author means that breakmodels crash the program, but
-    # correcting the case from tensor -> Tensor fixes it
-    substituteInPlace ./src/breakmodel.py --replace "torch.tensor" "torch.Tensor"
-    mv ./src $out
-    ln -s ${tmpDir}/models/ $out/models
-    ln -s ${tmpDir}/settings/ $out/settings
-    ln -s ${tmpDir}/userscripts/ $out/userscripts
+  inherit src;
+  patches = [
+    ./state-path.patch
+  ];
+
+  doCheck = false;
+  dontRewriteSymlinks = true;
+
+  passAsFile = [ "setup" "wrapper" ];
+  inherit stateDir;
+  postPatch = ''
+    substituteAll $setupPath setup.py
+
+    substituteAllInPlace aiserver.py \
+      --replace 'shutil.rmtree("cache/")' 'shutil.rmtree(CACHE_DIR)' \
+      --replace 'cache_dir="cache"' "cache_dir=CACHE_DIR"
+
+    sed -i -e 's|^git\+.*/mkultra$|mkultra|' requirements.txt
   '';
-  koboldPython = aipython3.python.withPackages (_: with aipython3; [
-    overrides.bleach
-    overrides.transformers
+
+  staticPaths = [
+    "colab" "maps" "static" "templates"
+    "cores" "extern"
+  ];
+  sharedPaths = [
+    "models" "userscripts" "settings" "stories"
+  ];
+  inherit (pythonPackages.python) sitePackages;
+  postInstall = ''
+    substituteAll $wrapperPath $out/bin/koboldai
+    chmod +x $out/bin/*
+
+    install -d $out/lib/$pname
+    for static_path in $staticPaths *.lua; do
+      mv $static_path $out/$sitePackages/
+      ln -s $out/$sitePackages/$static_path $out/lib/$pname/
+    done
+
+    for shared_path in $sharedPaths; do
+      install -d $out/lib/$pname/$shared_path
+      if [[ -e $out/$sitePackages/$shared_path ]]; then
+        lndir -silent $out/$sitePackages/$shared_path $out/lib/$pname/$shared_path
+      fi
+    done
+  '';
+
+  propagatedBuildInputs = with pythonPackages; [
+    bleach
+    transformers
     colorama
     flask
     flask-socketio
@@ -86,30 +111,70 @@ let
     apispec-webframeworks
     lupa
     memcached
-  ]);
-in
-(writeShellScriptBin "koboldai" ''
-  if [ -d "/usr/lib/wsl/lib" ]
-  then
-    echo "Running via WSL (Windows Subsystem for Linux), setting LD_LIBRARY_PATH"
-    set -x
-    export LD_LIBRARY_PATH="/usr/lib/wsl/lib"
-    set +x
-  fi
-  rm -rf ${tmpDir}
-  mkdir -p ${tmpDir}
-  mkdir -p ${stateDir}/models ${stateDir}/cache ${stateDir}/settings ${stateDir}/userscripts
-  ln -s ${stateDir}/models/   ${tmpDir}/models
-  ln -s ${stateDir}/settings/ ${tmpDir}/settings
-  ln -s ${stateDir}/userscripts/ ${tmpDir}/userscripts
-  ${koboldPython}/bin/python ${patchedSrc}/aiserver.py $@
-'').overrideAttrs
-  (_: {
-    meta = {
-      maintainers = [ lib.maintainers.matthewcroughan ];
-      license = lib.licenses.agpl3;
-      description = "browser-based front-end for AI-assisted writing with multiple local & remote AI models";
-      homepage = "https://github.com/KoboldAI/KoboldAI-Client";
-      mainProgram = "koboldai";
-    };
-  })
+    accelerate
+  ];
+
+  nativeBuildInputs = [
+    lndir
+    pythonPackages.pythonRelaxDepsHook
+  ];
+
+  pythonRemoveDeps = [ "mkultra" "flask-ngrok" "flask-cloudflared" ];
+  pythonRelaxDeps = [ "dnspython" "lupa" "torch" "transformers" ];
+
+  setup = ''
+    from io import open
+    from glob import glob
+    from setuptools import find_packages, setup
+
+    with open('requirements.txt') as f:
+      requirements = f.read().splitlines()
+
+    py_modules = [m.removesuffix('.py') for m in glob('*.py')]
+    py_modules.remove('setup')
+    py_modules.remove('aiserver')
+    setup(
+      name='@pname@',
+      version='@version@',
+      install_requires=requirements,
+      py_modules=py_modules,
+      scripts=[
+        'aiserver.py',
+      ],
+    )
+  '';
+
+  wrapper = ''
+    set -eu
+
+    if [ -d "/usr/lib/wsl/lib" ]; then
+      echo "Running via WSL (Windows Subsystem for Linux), setting LD_LIBRARY_PATH"
+      set -x
+      export LD_LIBRARY_PATH="/usr/lib/wsl/lib"
+      set +x
+    fi
+
+    if [[ -d @stateDir@ ]]; then
+      find @stateDir@ -type l -lname "${builtins.storeDir}/*-@pname@-*/*" -delete
+    else
+      mkdir -p @stateDir@
+    fi
+    cd @stateDir@
+
+    cp -nr --no-preserve=mode @out@/lib/@pname@/* ./
+    mkdir -p cache
+
+    exec @out@/bin/aiserver.py "$@"
+  '';
+
+  meta = {
+    maintainers = [ lib.maintainers.matthewcroughan ];
+    license = lib.licenses.agpl3;
+    description = "browser-based front-end for AI-assisted writing with multiple local & remote AI models";
+    homepage = "https://github.com/KoboldAI/KoboldAI-Client";
+    mainProgram = "koboldai";
+  };
+  passthru = {
+    inherit pythonPackages;
+  };
+}

--- a/projects/koboldai/state-path.patch
+++ b/projects/koboldai/state-path.patch
@@ -1,0 +1,34 @@
+diff --git a/aiserver.py b/aiserver.py
+--- a/aiserver.py
++++ b/aiserver.py
+@@ -6,6 +6,6 @@
+-os.system("")
++STATE_DIR = os.path.expandvars("@stateDir@")
++CACHE_DIR = os.path.join(STATE_DIR, "cache")
+ __file__ = os.path.dirname(os.path.realpath(__file__))
+-os.chdir(__file__)
+ os.environ['EVENTLET_THREADPOOL_SIZE'] = '1'
+ os.environ['TOKENIZERS_PARALLELISM'] = 'false'
+ from eventlet import tpool
+@@ -451,7 +451,7 @@ from werkzeug.exceptions import HTTPException, NotFound, InternalServerError
+ import secrets
+ app = Flask(__name__, root_path=os.getcwd())
+ app.secret_key = secrets.token_hex()
+-app.config['SESSION_TYPE'] = 'filesystem'
++app.config['SESSION_TYPE'] = 'memcached'
+ app.config['TEMPLATES_AUTO_RELOAD'] = True
+ socketio = SocketIO(app, async_method="eventlet")
+ 
+diff --git a/breakmodel.py b/breakmodel.py
+index 5200033..9af625f 100644
+--- a/breakmodel.py
++++ b/breakmodel.py
+@@ -358,7 +358,7 @@ def move_hidden_layers(transformer, h=None):
+     for i in range(ram_blocks):
+         h[i].to("cpu")
+         transformer.extrastorage[i] = copy.deepcopy(h[i])
+-        smalltensor = torch.tensor(0).to(primary_device)
++        smalltensor = torch.Tensor(0).to(primary_device)
+         for param1 in h[i].parameters():
+             param1.data = smalltensor
+         h[i].to(primary_device)


### PR DESCRIPTION
An initial swing at using buildPythonPackage for koboldai, with work toward eliminating `stateDir`/`tmpDir`.

An improvement might be to get rid of `stateDir` entirely, and just patch in `KOBOLDAI_ROOT` or a similar env var, with a fallback to `$XDG_DATA_HOME/koboldai` or something. Further improvement would of course involve patching the paths enough to remove the need for symlinks entirely.