### PR TITLE
Update InvokeAI to v2.3.5.post2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -119,16 +119,16 @@
     "invokeai-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1677475057,
-        "narHash": "sha256-REtyVcyRgspn1yYvB4vIHdOrPRZRNSSraepHik9MfgE=",
+        "lastModified": 1684768600,
+        "narHash": "sha256-ISkMOEybTyfoEKY5LLToXim1ZeT+A2ljhwLpj0Hfq8I=",
         "owner": "invoke-ai",
         "repo": "InvokeAI",
-        "rev": "650f4bb58ceca458bff1410f35cd6d6caad399c6",
+        "rev": "f3b2e02921927d9317255b1c3811f47bd40a2bf9",
         "type": "github"
       },
       "original": {
         "owner": "invoke-ai",
-        "ref": "v2.3.1.post2",
+        "ref": "v2.3.5.post2",
         "repo": "InvokeAI",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       url = "github:NixOS/nixpkgs/nixos-unstable";
     };
     invokeai-src = {
-      url = "github:invoke-ai/InvokeAI/v2.3.1.post2";
+      url = "github:invoke-ai/InvokeAI/v2.3.5.post2";
       flake = false;
     };
     koboldai-src = {

--- a/modules/aipython3/overlays.nix
+++ b/modules/aipython3/overlays.nix
@@ -82,6 +82,12 @@ pkgs: {
     clip-anytorch = callPackage ../../packages/clip-anytorch { };
     clean-fid = callPackage ../../packages/clean-fid { };
     getpass-asterisk = callPackage ../../packages/getpass-asterisk { };
+    fastapi = callPackage ../../packages/fastapi { };
+    fastapi-events = callPackage ../../packages/fastapi-events { };
+    fastapi-socketio = callPackage ../../packages/fastapi-socketio { };
+    starlette = callPackage ../../packages/starlette { };
+    peft = callPackage ../../packages/peft { };
+    huggingface-hub = callPackage ../../packages/huggingface-hub { };
   };
 
   torchRocm = final: prev: rec {
@@ -91,9 +97,9 @@ pkgs: {
     # you can run this thing without the fix by creating /opt and running nix build nixpkgs#libdrm --inputs-from . --out-link /opt/amdgpu
     torch-bin = prev.torch-bin.overrideAttrs (old: {
       src = pkgs.fetchurl {
-        name = "torch-1.13.1+rocm5.1.1-cp310-cp310-linux_x86_64.whl";
-        url = "https://download.pytorch.org/whl/rocm5.1.1/torch-1.13.1%2Brocm5.1.1-cp310-cp310-linux_x86_64.whl";
-        hash = "sha256-qUwAL3L9ODy9hjne8jZQRoG4BxvXXLT7cAy9RbM837A=";
+        name = "torch-2.0.1+cpu.cxx11.abi-cp310-cp310-linux_x86_64.whl";
+        url = "https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.0.1%2Bcpu.cxx11.abi-cp310-cp310-linux_x86_64.whl";
+        hash = "sha256-IWbYvzl3h0yNZKZ+EXPWA5SM3lz6Lp9zxtH3soVlmes=";
       };
       postFixup = (old.postFixup or "") + ''
         ${pkgs.gnused}/bin/sed -i s,/opt/amdgpu/share/libdrm/amdgpu.ids,/tmp/nix-pytorch-rocm___/amdgpu.ids,g $out/${final.python.sitePackages}/torch/lib/libdrm_amdgpu.so

--- a/packages/accelerate/default.nix
+++ b/packages/accelerate/default.nix
@@ -6,11 +6,11 @@
 
 buildPythonPackage rec {
   pname = "accelerate";
-  version = "0.13.1";
+  version = "0.16.0";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1dk82s80rq8xp3v4hr9a27vgj9k3gy9yssp7ww7i3c0vc07gx2cv";
+    sha256 = "sha256-0T4w8+bev7Rsrae5Ma+FVgYZtqaoOdDK/uq27XxqSY0=";
   };
 
   propagatedBuildInputs = [ numpy packaging psutil pyyaml torch ];

--- a/packages/compel/default.nix
+++ b/packages/compel/default.nix
@@ -2,12 +2,12 @@
 
 buildPythonPackage rec {
   pname = "compel";
-  version = "0.1.7";
+  version = "1.1.5";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-JP+PX0yENTNnfsAJ/hzgIA/cr/RhIWV1GEa1rYTdlnc=";
+    sha256 = "sha256-kypESFU5g9sz9Ik1FiOe1QAbOEzCEeMoQegLH5Tc0PY=";
   };
 
   propagatedBuildInputs = [

--- a/packages/diffusers/default.nix
+++ b/packages/diffusers/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage rec {
   pname = "diffusers";
-  version = "0.14.0";
+  version = "0.16.1";
 
   disabled = isPy27;
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "sha256-sqQqEtq1OMtFo7DGVQMFO6RG5fLfSDbeOFtSON+DCkY=";
+    sha256 = "sha256-TNdAA4LIbYXghCVVDeGxqB1O0DYj+9S82Dd4ZNnEbv4=";
   };
 
   propagatedBuildInputs = [

--- a/packages/fastapi-events/default.nix
+++ b/packages/fastapi-events/default.nix
@@ -1,0 +1,24 @@
+{ buildPythonPackage, fetchPypi, setuptools, starlette }:
+
+buildPythonPackage rec {
+  pname = "fastapi-events";
+  version = "0.6.0";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-I4DNw+MNyJjWtyHWI8V1xvWwXuNaPuBa3wuQsSue0fk=";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    starlette
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "An event dispatching/handling library for FastAPI, and Starlette.";
+    homepage = "https://github.com/tiangolo/fastapi-events";
+  };
+}

--- a/packages/fastapi-socketio/default.nix
+++ b/packages/fastapi-socketio/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage, fetchPypi, setuptools, python-socketio, fastapi }:
+
+buildPythonPackage rec {
+  pname = "fastapi-socketio";
+  version = "0.0.9";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-jHOqlP4b8cmWT/iSM6a6Uu7uw6yLneACTZ2CsR5GveU=";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    python-socketio
+    fastapi
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Easly integrate socket.io with your FastAPI app.";
+    homepage = "https://github.com/pyropy/fastapi-socketio";
+  };
+}

--- a/packages/fastapi/default.nix
+++ b/packages/fastapi/default.nix
@@ -1,0 +1,24 @@
+{ buildPythonPackage, fetchPypi, hatchling, starlette }:
+
+buildPythonPackage rec {
+  pname = "fastapi";
+  version = "0.85.0";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-uyGc+v0NLM+PMjEMmiV6BrAhC9jioDcGpvWp+fFBaHg=";
+  };
+
+  propagatedBuildInputs = [
+    hatchling
+    starlette
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "FastAPI is a modern, fast (high-performance), web framework for building APIs with Python 3.7+ based on standard Python type hints.";
+    homepage = "https://github.com/tiangolo/fastapi";
+  };
+}

--- a/packages/huggingface-hub/default.nix
+++ b/packages/huggingface-hub/default.nix
@@ -1,0 +1,29 @@
+{ buildPythonPackage, fetchPypi, setuptools, tqdm, pyyaml, fsspec, filelock, packaging }:
+
+buildPythonPackage rec {
+  pname = "huggingface-hub";
+  version = "0.15.1";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "huggingface_hub";
+    sha256 = "sha256-pht9Gndp/hARnnMCd8cquZ2VxI2Go9baPp89D2MqQIE=";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    tqdm
+    pyyaml
+    fsspec
+    filelock
+    packaging
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "The huggingface_hub is a client library to interact with the Hugging Face Hub.";
+    homepage = "https://github.com/huggingface/huggingface_hub";
+  };
+}

--- a/packages/peft/default.nix
+++ b/packages/peft/default.nix
@@ -1,0 +1,27 @@
+{ buildPythonPackage, fetchPypi, setuptools, packaging, numpy, accelerate, transformers }:
+
+buildPythonPackage rec {
+  pname = "peft";
+  version = "0.3.0";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-u97uTeNlPuQ8trvnUFgW5um0z4J1RxvhcH2cJT3+jgs=";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    packaging
+    numpy
+    accelerate
+    transformers
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "State-of-the-art Parameter-Efficient Fine-Tuning (PEFT) methods";
+    homepage = "https://github.com/huggingface/peft";
+  };
+}

--- a/packages/safetensors/default.nix
+++ b/packages/safetensors/default.nix
@@ -21,12 +21,12 @@
 let
 
   pname = "safetensors";
-  version = "0.2.8";
+  version = "0.3.0";
 
   patchedSrc = runCommand "patched-src" {
     src = fetchPypi {
       inherit pname version;
-      hash = "sha256-JyCyCmo4x5ncp5vXbK7qwvffWFqdT31Z+n4o7/nMsn8=";
+      hash = "sha256-W+iy/M3GrshMnWcyGAV1/hujr8VZy+luIwHqzEXFuaY=";
     };
   } ''
     unpackPhase
@@ -43,7 +43,7 @@ buildPythonPackage {
   cargoDeps = rustPlatform.fetchCargoTarball {
     src = patchedSrc;
     name = "${pname}-${version}";
-    hash = "sha256-IZKaw4NquK/BbIv1xkMFgNR20vve4H6Re76mvxtcNUA=";
+    hash = "sha256-z6LJ4nzQ99NKy0prLvb1YpDd0VC5CqSd0nCBp61EhWE=";
   };
 
   nativeBuildInputs = [
@@ -58,9 +58,6 @@ buildPythonPackage {
   propagatedBuildInputs = [
     black
     click
-#    flake
-#    flax
-#    h
     huggingface-hub
     isort
     jax

--- a/packages/starlette/default.nix
+++ b/packages/starlette/default.nix
@@ -1,0 +1,25 @@
+{ buildPythonPackage, fetchPypi, setuptools, anyio, pydantic }:
+
+buildPythonPackage rec {
+  pname = "starlette";
+  version = "0.20.4";
+  format = "pyproject";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-QvzzEi+Zj+/OPixa1+Xtvw8Cz2hdZGqDoI1ARyavUIQ=";
+  };
+
+  propagatedBuildInputs = [
+    setuptools
+    anyio
+    pydantic
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Starlette is a lightweight ASGI framework/toolkit, which is ideal for building async web services in Python.";
+    homepage = "https://github.com/encode/starlette";
+  };
+}

--- a/projects/invokeai/package.nix
+++ b/projects/invokeai/package.nix
@@ -57,10 +57,17 @@ aipython3.buildPythonPackage {
     getpass-asterisk
     safetensors
     datasets
+    fastapi
+    fastapi-events
+    fastapi-socketio
+    peft
+    accelerate
+    python-multipart
+    diffusers
   ];
   nativeBuildInputs = [ aipython3.pythonRelaxDepsHook ];
   pythonRemoveDeps = [ "clip" "pyreadline3" "flaskwebgui" "opencv-python" ];
-  pythonRelaxDeps = [ "dnspython" "protobuf" "flask" "flask-socketio" "pytorch-lightning" ];
+  pythonRelaxDeps = [ "dnspython" "protobuf" "flask" "flask-socketio" "pytorch-lightning" "torch" "transformers" ];
   makeWrapperArgs = [
     '' --run '
       if [ -d "/usr/lib/wsl/lib" ]

--- a/projects/invokeai/package.nix
+++ b/projects/invokeai/package.nix
@@ -1,8 +1,8 @@
 { aipython3
-# misc
+  # misc
 , lib
 , src
-# extra deps
+  # extra deps
 , libdrm
 }:
 
@@ -69,46 +69,56 @@ aipython3.buildPythonPackage {
   pythonRemoveDeps = [ "clip" "pyreadline3" "flaskwebgui" "opencv-python" ];
   pythonRelaxDeps = [ "dnspython" "protobuf" "flask" "flask-socketio" "pytorch-lightning" "torch" "transformers" ];
   makeWrapperArgs = [
-    '' --run '
-      if [ -d "/usr/lib/wsl/lib" ]
-      then
-          echo "Running via WSL (Windows Subsystem for Linux), setting LD_LIBRARY_PATH=/usr/lib/wsl/lib"
-          set -x
-          export LD_LIBRARY_PATH="/usr/lib/wsl/lib"
-          set +x
-      fi
-      '
+    ''
+      --run '
+         if [ ! -d "${builtins.getEnv "HOME"}/invokeai" ]
+         then
+           echo "Running invokeai-configure"
+           set -x
+           invokeai-configure
+           set +x
+         fi
+         '
+      --run '
+          if [ -d "/usr/lib/wsl/lib" ]
+          then
+              echo "Running via WSL (Windows Subsystem for Linux), setting LD_LIBRARY_PATH=/usr/lib/wsl/lib"
+              set -x
+              export LD_LIBRARY_PATH="/usr/lib/wsl/lib"
+              set +x
+          fi
+          '
     ''
   ] ++ lib.optionals (aipython3.torch.rocmSupport or false) [
     '' --run '
-      if [ ! -e /tmp/nix-pytorch-rocm___/amdgpu.ids ]
-      then
-          mkdir -p /tmp/nix-pytorch-rocm___
-          ln -s ${libdrm}/share/libdrm/amdgpu.ids /tmp/nix-pytorch-rocm___/amdgpu.ids
-      fi
-      '
+          if [ ! -e /tmp/nix-pytorch-rocm___/amdgpu.ids ]
+          then
+              mkdir -p /tmp/nix-pytorch-rocm___
+              ln -s ${libdrm}/share/libdrm/amdgpu.ids /tmp/nix-pytorch-rocm___/amdgpu.ids
+          fi
+          '
     ''
     # See note about consumer GPUs:
     # https://docs.amd.com/bundle/ROCm-Deep-Learning-Guide-v5.4.3/page/Troubleshooting.html
     " --set-default HSA_OVERRIDE_GFX_VERSION 10.3.0"
   ];
   patchPhase = ''
-    runHook prePatch
+        runHook prePatch
 
-    # Add subprocess to the imports
-    substituteInPlace ./ldm/invoke/config/invokeai_configure.py --replace \
-        'import shutil' \
-'
-import shutil
-import subprocess
-'
-    # shutil.copytree will inherit the permissions of files in the /nix/store
-    # which are read only, so we subprocess.call cp instead and tell it not to
-    # preserve the mode
-    substituteInPlace ./ldm/invoke/config/invokeai_configure.py --replace \
-      "shutil.copytree(configs_src, configs_dest, dirs_exist_ok=True)" \
-      "subprocess.call('cp -r --no-preserve=mode {configs_src} {configs_dest}'.format(configs_src=configs_src, configs_dest=configs_dest), shell=True)"
-    runHook postPatch
+        # Add subprocess to the imports
+        substituteInPlace ./ldm/invoke/config/invokeai_configure.py --replace \
+            'import shutil' \
+    '
+    import shutil
+    import subprocess
+    '
+        # shutil.copytree will inherit the permissions of files in the /nix/store
+        # which are read only, so we subprocess.call cp instead and tell it not to
+        # preserve the mode
+        substituteInPlace ./ldm/invoke/config/invokeai_configure.py --replace \
+          "shutil.copytree(configs_src, configs_dest, dirs_exist_ok=True)" \
+          "subprocess.call('cp -r --no-preserve=mode {configs_src} {configs_dest}'.format(configs_src=configs_src, configs_dest=configs_dest), shell=True)"
+        runHook postPatch
   '';
   postFixup = ''
     chmod +x $out/bin/*

--- a/projects/invokeai/package.nix
+++ b/projects/invokeai/package.nix
@@ -73,8 +73,11 @@ aipython3.buildPythonPackage {
       if [ ! -d "$HOME/invokeai" ]
       then
           echo "Running invokeai-configure"
-          mkdir -p $HOME/invokeai/configs
+          set -x
+          mkdir -p $HOME/invokeai/configs/stable-diffusion
           invokeai-configure
+          cp $HOME/invokeai/configs/configs/stable-diffusion/v1-inference.yaml $HOME/invokeai/configs/stable-diffusion/v1-inference.yaml
+          set +x
       fi
 
       if [ -d "/usr/lib/wsl/lib" ]

--- a/projects/invokeai/package.nix
+++ b/projects/invokeai/package.nix
@@ -1,8 +1,8 @@
 { aipython3
-  # misc
+# misc
 , lib
 , src
-  # extra deps
+# extra deps
 , libdrm
 }:
 
@@ -69,56 +69,53 @@ aipython3.buildPythonPackage {
   pythonRemoveDeps = [ "clip" "pyreadline3" "flaskwebgui" "opencv-python" ];
   pythonRelaxDeps = [ "dnspython" "protobuf" "flask" "flask-socketio" "pytorch-lightning" "torch" "transformers" ];
   makeWrapperArgs = [
-    ''
-      --run '
-         if [ ! -d "${builtins.getEnv "HOME"}/invokeai" ]
-         then
-           echo "Running invokeai-configure"
-           set -x
-           invokeai-configure
-           set +x
-         fi
-         '
-      --run '
-          if [ -d "/usr/lib/wsl/lib" ]
-          then
-              echo "Running via WSL (Windows Subsystem for Linux), setting LD_LIBRARY_PATH=/usr/lib/wsl/lib"
-              set -x
-              export LD_LIBRARY_PATH="/usr/lib/wsl/lib"
-              set +x
-          fi
-          '
+    '' --run '
+      if [ ! -d "$HOME/invokeai" ]
+      then
+          echo "Running invokeai-configure"
+          mkdir -p $HOME/invokeai/configs
+          invokeai-configure
+      fi
+
+      if [ -d "/usr/lib/wsl/lib" ]
+      then
+          echo "Running via WSL (Windows Subsystem for Linux), setting LD_LIBRARY_PATH=/usr/lib/wsl/lib"
+          set -x
+          export LD_LIBRARY_PATH="/usr/lib/wsl/lib"
+          set +x
+      fi
+      '
     ''
   ] ++ lib.optionals (aipython3.torch.rocmSupport or false) [
     '' --run '
-          if [ ! -e /tmp/nix-pytorch-rocm___/amdgpu.ids ]
-          then
-              mkdir -p /tmp/nix-pytorch-rocm___
-              ln -s ${libdrm}/share/libdrm/amdgpu.ids /tmp/nix-pytorch-rocm___/amdgpu.ids
-          fi
-          '
+      if [ ! -e /tmp/nix-pytorch-rocm___/amdgpu.ids ]
+      then
+          mkdir -p /tmp/nix-pytorch-rocm___
+          ln -s ${libdrm}/share/libdrm/amdgpu.ids /tmp/nix-pytorch-rocm___/amdgpu.ids
+      fi
+      '
     ''
     # See note about consumer GPUs:
     # https://docs.amd.com/bundle/ROCm-Deep-Learning-Guide-v5.4.3/page/Troubleshooting.html
     " --set-default HSA_OVERRIDE_GFX_VERSION 10.3.0"
   ];
   patchPhase = ''
-        runHook prePatch
+    runHook prePatch
 
-        # Add subprocess to the imports
-        substituteInPlace ./ldm/invoke/config/invokeai_configure.py --replace \
-            'import shutil' \
-    '
-    import shutil
-    import subprocess
-    '
-        # shutil.copytree will inherit the permissions of files in the /nix/store
-        # which are read only, so we subprocess.call cp instead and tell it not to
-        # preserve the mode
-        substituteInPlace ./ldm/invoke/config/invokeai_configure.py --replace \
-          "shutil.copytree(configs_src, configs_dest, dirs_exist_ok=True)" \
-          "subprocess.call('cp -r --no-preserve=mode {configs_src} {configs_dest}'.format(configs_src=configs_src, configs_dest=configs_dest), shell=True)"
-        runHook postPatch
+    # Add subprocess to the imports
+    substituteInPlace ./ldm/invoke/config/invokeai_configure.py --replace \
+        'import shutil' \
+'
+import shutil
+import subprocess
+'
+    # shutil.copytree will inherit the permissions of files in the /nix/store
+    # which are read only, so we subprocess.call cp instead and tell it not to
+    # preserve the mode
+    substituteInPlace ./ldm/invoke/config/invokeai_configure.py --replace \
+      "shutil.copytree(configs_src, configs_dest, dirs_exist_ok=True)" \
+      "subprocess.call('cp -r --no-preserve=mode {configs_src} {configs_dest}'.format(configs_src=configs_src, configs_dest=configs_dest), shell=True)"
+    runHook postPatch
   '';
   postFixup = ''
     chmod +x $out/bin/*


### PR DESCRIPTION
This works fine for me so far, but only when I have a ``invokeai`` folder pre-generated from before.
Unlike the previous version of InvokeAI used in this flake, it doesn't seem to run the configure script for you on startup when it's missing.

Their README states to run ``invokeai-configure`` as part of the initial configuration. How can I make the flake automatically run this command when the ``invokeai`` folder is missing?