### PR TITLE
rembg: add

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ The main outputs of the `flake.nix` at the moment are as follows:
 
 ![invokeai](/../images/invokeai.webp)
 
+#### Rembg ( Automatic Background Remover )
+
+- `nix run .#rembg-cpu -- i input.png output.png`
+- `nix run .#rembg-cpu -- s --port 9226`
+
+![rembg UI](/../images/rembg.webp)
+
 ## Install NixOS-WSL in Windows
 
 If you're interested in running nixified.ai in the Windows Subsystem for Linux, you'll need to enable the WSL and then install NixOS-WSL via it. We provide a script that will do everything for you.

--- a/flake.lock
+++ b/flake.lock
@@ -245,13 +245,31 @@
         "type": "github"
       }
     },
+    "rembg-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1689217026,
+        "narHash": "sha256-ysYsbD+srq4PgkzyXbwiuP6DlE4wzhydpxINf+rireY=",
+        "owner": "danielgatis",
+        "repo": "rembg",
+        "rev": "a9c2a39213127073247637f441f1a94e8c61eee8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "danielgatis",
+        "ref": "v2.0.50",
+        "repo": "rembg",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "hercules-ci-effects": "hercules-ci-effects",
         "invokeai-src": "invokeai-src",
         "koboldai-src": "koboldai-src",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "rembg-src": "rembg-src"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,10 @@
       url = "github:koboldai/koboldai-client/1.19.2";
       flake = false;
     };
+    rembg-src = {
+      url = "github:danielgatis/rembg/v2.0.50";
+      flake = false;
+    };
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
@@ -38,6 +42,7 @@
         ./modules/aipython3
         ./projects/invokeai
         ./projects/koboldai
+        ./projects/rembg
         ./website
       ];
   };

--- a/modules/aipython3/default.nix
+++ b/modules/aipython3/default.nix
@@ -18,6 +18,11 @@
         overlays.torchRocm
       ];
 
+      aipython3-cpu = mkPythonPackages [
+        overlays.fixPackages
+        overlays.extraDeps
+      ];
+
       aipython3-nvidia = mkPythonPackages [
         overlays.fixPackages
         overlays.extraDeps

--- a/modules/aipython3/overlays.nix
+++ b/modules/aipython3/overlays.nix
@@ -48,6 +48,8 @@ pkgs: {
     opencv-python-headless = final.opencv-python;
     opencv-python = final.opencv4;
 
+    asyncer = callPackage ../../packages/asyncer { };
+    pymatting = callPackage ../../packages/pymatting { };
     safetensors = callPackage ../../packages/safetensors { };
     compel = callPackage ../../packages/compel { };
     apispec-webframeworks = callPackage ../../packages/apispec-webframeworks { };

--- a/packages/asyncer/default.nix
+++ b/packages/asyncer/default.nix
@@ -1,0 +1,25 @@
+# WARNING: This file was automatically generated. You should avoid editing it.
+# If you run pynixify again, the file will be either overwritten or
+# deleted, and you will lose the changes you made to it.
+
+{ anyio, buildPythonPackage, fetchPypi, lib }:
+
+buildPythonPackage rec {
+  pname = "asyncer";
+  version = "0.0.2";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "0czlyysclcs1lyqh5j3a3ak05jb1jys5sfdldgqbmsr66rgwhinm";
+  };
+
+  propagatedBuildInputs = [ anyio ];
+
+  # TODO FIXME
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Asyncer, async and await, focused on developer experience.";
+    homepage = "https://github.com/tiangolo/asyncer";
+  };
+}

--- a/packages/pymatting/default.nix
+++ b/packages/pymatting/default.nix
@@ -1,0 +1,26 @@
+# WARNING: This file was automatically generated. You should avoid editing it.
+# If you run pynixify again, the file will be either overwritten or
+# deleted, and you will lose the changes you made to it.
+
+{ buildPythonPackage, fetchPypi, lib, numba, numpy, pillow, scipy }:
+
+buildPythonPackage rec {
+  pname = "pymatting";
+  version = "1.1.8";
+
+  src = fetchPypi {
+    inherit version;
+    pname = "PyMatting";
+    sha256 = "1k1aacqrpx03vh7d37vq9m40j6hmcfyf716jvwqni6bl13phhdd7";
+  };
+
+  propagatedBuildInputs = [ numpy pillow numba scipy ];
+
+  # TODO FIXME
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Python package for alpha matting.";
+    homepage = "https://pymatting.github.io";
+  };
+}

--- a/projects/rembg/default.nix
+++ b/projects/rembg/default.nix
@@ -1,0 +1,37 @@
+{ config, inputs, lib, withSystem, ... }:
+
+{
+  perSystem = { config, pkgs, ... }:
+    let
+      inherit (config.dependencySets) aipython3-cpu;
+
+      src = inputs.rembg-src;
+
+      mkInvokeAIVariant = args: pkgs.callPackage ./package.nix ({ inherit src; } // args);
+    in
+    {
+      packages = {
+        rembg-cpu = mkInvokeAIVariant {
+          aipython3 = aipython3-cpu;
+        };
+      };
+    };
+
+  flake.nixosModules =
+    let
+      packageModule = pkgAttrName: { pkgs, ... }: {
+        services.rembg.package = withSystem pkgs.system (
+          { config, ... }: lib.mkOptionDefault config.packages.${pkgAttrName}
+        );
+      };
+    in
+    {
+      rembg = ./nixos;
+      rembg-cpu = {
+        imports = [
+          config.flake.nixosModules.rembg
+          (packageModule "rembg-cpu")
+        ];
+      };
+    };
+}

--- a/projects/rembg/package.nix
+++ b/projects/rembg/package.nix
@@ -1,0 +1,56 @@
+{ aipython3
+, callPackage
+, src
+}:
+let
+  abseil-onnx = callPackage ./packages/abseil-onnx { };
+  microsoft-gsl = callPackage ./packages/microsoft-gsl { };
+  onnx-custom = callPackage ./packages/onnx { inherit aipython3; };
+  onnxruntime = callPackage ./packages/onnxruntime { inherit aipython3 microsoft-gsl onnx-custom; abseil-cpp = abseil-onnx; };
+  onnxruntime-pyt = callPackage ./packages/onnxruntime-python
+    { inherit aipython3 onnxruntime; };
+in
+
+aipython3.buildPythonPackage {
+  pname = "rembg";
+  format = "pyproject";
+  version = "2.0.50";
+  inherit src;
+  propagatedBuildInputs = with aipython3; [
+    numpy
+    onnxruntime-pyt
+    opencv4
+    pillow
+    pooch
+    pymatting
+    scikit-image
+    scipy
+    setuptools
+    tqdm
+
+    # {{{ cli deps
+    aiohttp
+    asyncer
+    click
+    fastapi
+    filetype
+    gradio
+    python-multipart
+    uvicorn
+    watchdog
+    # }}}
+  ];
+  nativeBuildInputs = [ aipython3.pythonRelaxDepsHook ];
+  pythonRemoveDeps = [ "clip" "pyreadline3" "flaskwebgui" "opencv-python" ];
+  pythonRelaxDeps = [ "dnspython" "protobuf" "flask" "flask-socketio" "pytorch-lightning" ];
+  postFixup = ''
+    chmod +x $out/bin/*
+    wrapPythonPrograms
+  '';
+  doCheck = false;
+  meta = {
+    description = "tool to remove image backgrounds";
+    homepage = "https://github.com/danielgatis/rembg/";
+    mainProgram = "rembg";
+  };
+}

--- a/projects/rembg/packages/abseil-onnx/default.nix
+++ b/projects/rembg/packages/abseil-onnx/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, static ? stdenv.hostPlatform.isStatic
+, cxxStandard ? null
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "abseil-cpp";
+  version = "20230125.3";
+
+  src = fetchFromGitHub {
+    owner = "abseil";
+    repo = "abseil-cpp";
+    rev = "refs/tags/${finalAttrs.version}";
+    hash = "sha256-PLoI7ix+reUqkZ947kWzls8lujYqWXk9A9a55UcfahI=";
+  };
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if static then "OFF" else "ON"}"
+  ] ++ lib.optionals (cxxStandard != null) [
+    "-DCMAKE_CXX_STANDARD=${cxxStandard}"
+  ];
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "An open-source collection of C++ code designed to augment the C++ standard library";
+    homepage = "https://abseil.io/";
+    license = licenses.asl20;
+    platforms = platforms.all;
+    maintainers = [ maintainers.andersk ];
+  };
+})

--- a/projects/rembg/packages/microsoft-gsl/default.nix
+++ b/projects/rembg/packages/microsoft-gsl/default.nix
@@ -1,0 +1,37 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, gtest
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "microsoft-gsl";
+  version = "4.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Microsoft";
+    repo = "GSL";
+    rev = "v${version}";
+    hash = "sha256-cXDFqt2KgMFGfdh6NGE+JmP4R0Wm9LNHM0eIblYe6zU=";
+  };
+
+  nativeBuildInputs = [ cmake pkg-config ];
+  buildInputs = [ gtest ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "C++ Core Guideline support library";
+    longDescription = ''
+      The Guideline Support Library (GSL) contains functions and types that are suggested for
+      use by the C++ Core Guidelines maintained by the Standard C++ Foundation.
+      This package contains Microsoft's implementation of GSL.
+    '';
+    homepage = "https://github.com/Microsoft/GSL";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ thoughtpolice yuriaisaka ];
+  };
+}

--- a/projects/rembg/packages/onnx/default.nix
+++ b/projects/rembg/packages/onnx/default.nix
@@ -1,0 +1,138 @@
+{ lib
+, stdenv
+, aipython3
+, cmake
+, fetchFromGitHub
+, gtest
+}:
+
+let
+  gtestStatic = gtest.override { static = true; };
+in
+aipython3.buildPythonPackage rec {
+  pname = "onnx";
+  version = "1.14.0";
+  format = "setuptools";
+
+  disabled = aipython3.pythonOlder "3.8";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "refs/tags/v${version}";
+    hash = "sha256-f+s25Y/jGosaSdoZY6PE3j6pENkfDcD+IQndrbtuzWg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    aipython3.pybind11
+  ];
+
+  propagatedBuildInputs = [
+    aipython3.protobuf
+    aipython3.numpy
+    aipython3.typing-extensions
+  ];
+
+  nativeCheckInputs = with aipython3; [
+    nbval
+    parameterized
+    pytestCheckHook
+    tabulate
+  ];
+
+  postPatch = ''
+    chmod +x tools/protoc-gen-mypy.sh.in
+    patchShebangs tools/protoc-gen-mypy.sh.in
+
+    substituteInPlace setup.py \
+      --replace 'setup_requires.append("pytest-runner")' ""
+
+    substituteInPlace requirements.txt \
+      --replace 'protobuf>=3.20.2' ""
+
+    # prevent from fetching & building own gtest
+    substituteInPlace CMakeLists.txt \
+      --replace 'include(googletest)' ""
+    substituteInPlace cmake/unittest.cmake \
+      --replace 'googletest)' ')'
+  '';
+
+  preConfigure = ''
+    # Set CMAKE_INSTALL_LIBDIR to lib explicitly, because otherwise it gets set
+    # to lib64 and cmake incorrectly looks for the protobuf library in lib64
+    export CMAKE_ARGS="-DCMAKE_INSTALL_LIBDIR=lib -DONNX_USE_PROTOBUF_SHARED_LIBS=ON"
+    export CMAKE_ARGS+=" -Dgoogletest_STATIC_LIBRARIES=${gtestStatic}/lib/libgtest.a -Dgoogletest_INCLUDE_DIRS=${lib.getDev gtestStatic}/include"
+    export ONNX_BUILD_TESTS=1
+  '';
+
+  preBuild = ''
+    export MAX_JOBS=$NIX_BUILD_CORES
+  '';
+
+  # The executables are just utility scripts that aren't too important
+  postInstall = ''
+    rm -r $out/bin
+  '';
+
+  # The setup.py does all the configuration
+  dontUseCmakeConfigure = true;
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+
+    # detecting source dir as a python package confuses pytest
+    mv onnx/__init__.py onnx/__init__.py.hidden
+  '';
+
+  pytestFlagsArray = [
+    "onnx/test"
+    "onnx/examples"
+  ];
+
+  disabledTests = [
+    # attempts to fetch data from web
+    "test_bvlc_alexnet_cpu"
+    "test_densenet121_cpu"
+    "test_inception_v1_cpu"
+    "test_inception_v2_cpu"
+    "test_resnet50_cpu"
+    "test_shufflenet_cpu"
+    "test_squeezenet_cpu"
+    "test_vgg19_cpu"
+    "test_zfnet512_cpu"
+  ] ++ lib.optionals stdenv.isAarch64 [
+    # AssertionError: Output 0 of test 0 in folder
+    "test__pytorch_converted_Conv2d_depthwise_padded"
+    "test__pytorch_converted_Conv2d_dilated"
+    "test_dft"
+    "test_dft_axis"
+    # AssertionError: Mismatch in test 'test_Conv2d_depthwise_padded'
+    "test_xor_bcast4v4d"
+    # AssertionError: assert 1 == 0
+    "test_ops_tested"
+  ];
+
+  disabledTestPaths = [
+    # Unexpected output fields from running code: {'stderr'}
+    "onnx/examples/np_array_tensorproto.ipynb"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  postCheck = ''
+    # run "cpp" tests
+    .setuptools-cmake-build/onnx_gtests
+  '';
+
+  pythonImportsCheck = [
+    "onnx"
+  ];
+
+  meta = with lib; {
+    description = "Open Neural Network Exchange";
+    homepage = "https://onnx.ai";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ acairncross ];
+  };
+}

--- a/projects/rembg/packages/onnxruntime-python/default.nix
+++ b/projects/rembg/packages/onnxruntime-python/default.nix
@@ -1,0 +1,68 @@
+# WARNING: This file was not automatically generated.
+# If you run pynixify, the file will be either overwritten or
+# deleted, and you will lose the changes you made to it.
+
+{ lib
+, stdenv
+, aipython3
+, autoPatchelfHook
+, oneDNN
+, onnxruntime
+, re2
+}:
+
+# onnxruntime requires an older protobuf.
+# Doing an override in protobuf in the python-packages set
+# can give you a functioning Python package but note not
+# all Python packages will be compatible then.
+#
+# Because protobuf is not always needed we remove it
+# as a runtime dependency from our wheel.
+#
+# We do include here the non-Python protobuf so the shared libs
+# link correctly. If you do also want to include the Python
+# protobuf, you can add it to your Python env, but be aware
+# the version likely mismatches with what is used here.
+
+aipython3.buildPythonPackage {
+  inherit (onnxruntime) version;
+  pname = "onnxruntime-python";
+  format = "wheel";
+  src = onnxruntime.dist;
+
+  unpackPhase = ''
+    cp -r $src dist
+    chmod +w dist
+  '';
+
+  nativeBuildInputs = [
+    aipython3.pythonRelaxDepsHook
+  ] ++ lib.optionals stdenv.isLinux [
+    autoPatchelfHook
+  ];
+
+  # This project requires fairly large dependencies such as sympy which we really don't always need.
+  pythonRemoveDeps = [
+    "flatbuffers"
+    "protobuf"
+    "sympy"
+  ];
+
+  # Libraries are not linked correctly.
+  buildInputs = [
+    oneDNN
+    re2
+    onnxruntime.protobuf
+  ];
+
+  propagatedBuildInputs = with aipython3; [
+    coloredlogs
+    flatbuffers
+    numpy
+    packaging
+    protobuf
+    sympy
+  ];
+
+  meta = onnxruntime.meta // { maintainers = with lib.maintainers; [ fridh ]; };
+}

--- a/projects/rembg/packages/onnxruntime/default.nix
+++ b/projects/rembg/packages/onnxruntime/default.nix
@@ -1,0 +1,205 @@
+{ pkgs
+, stdenv
+, lib
+, abseil-cpp
+, aipython3
+, cmake
+, fetchFromGitHub
+, fetchFromGitLab
+, gtest
+, iconv
+, libpng
+, microsoft-gsl
+, nlohmann_json
+, nsync
+, onnx-custom
+, pkg-config
+, protobuf3_21
+, re2
+, zlib
+, pythonSupport ? true
+}:
+
+let
+  Foundation = if stdenv.isDarwin then pkgs.Foundation else { }; # TODO: Better way?
+  howard-hinnant-date = fetchFromGitHub {
+    owner = "HowardHinnant";
+    repo = "date";
+    rev = "v2.4.1";
+    sha256 = "sha256-BYL7wxsYRI45l8C3VwxYIIocn5TzJnBtU0UZ9pHwwZw=";
+  };
+
+  eigen = fetchFromGitLab {
+    owner = "libeigen";
+    repo = "eigen";
+    rev = "d10b27fe37736d2944630ecd7557cefa95cf87c9";
+    sha256 = "sha256-Lmco0s9gIm9sIw7lCr5Iewye3RmrHEE4HLfyzRkQCm0=";
+  };
+
+  mp11 = fetchFromGitHub {
+    owner = "boostorg";
+    repo = "mp11";
+    rev = "boost-1.79.0";
+    sha256 = "sha256-ZxgPDLvpISrjpEHKpLGBowRKGfSwTf6TBfJD18yw+LM=";
+  };
+
+  safeint = fetchFromGitHub {
+    owner = "dcleblanc";
+    repo = "safeint";
+    rev = "ff15c6ada150a5018c5ef2172401cb4529eac9c0";
+    sha256 = "sha256-PK1ce4C0uCR4TzLFg+elZdSk5DdPCRhhwT3LvEwWnPU=";
+  };
+
+  pytorch_cpuinfo = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "cpuinfo";
+    # There are no tags in the repository
+    rev = "5916273f79a21551890fd3d56fc5375a78d1598d";
+    sha256 = "sha256-nXBnloVTuB+AVX59VDU/Wc+Dsx94o92YQuHp3jowx2A=";
+  };
+
+  flatbuffers = fetchFromGitHub {
+    owner = "google";
+    repo = "flatbuffers";
+    rev = "v1.12.0";
+    sha256 = "sha256-L1B5Y/c897Jg9fGwT2J3+vaXsZ+lfXnskp8Gto1p/Tg=";
+  };
+
+  gtest' = gtest.overrideAttrs (oldAttrs: rec {
+    version = "1.13.0";
+    src = fetchFromGitHub {
+      owner = "google";
+      repo = "googletest";
+      rev = "v${version}";
+      hash = "sha256-LVLEn+e7c8013pwiLzJiiIObyrlbBHYaioO/SWbItPQ=";
+    };
+  });
+in
+stdenv.mkDerivation rec {
+  pname = "onnxruntime";
+  version = "1.15.1";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "onnxruntime";
+    rev = "v${version}";
+    sha256 = "sha256-SnHo2sVACc++fog7Tg6f2LK/Sv/EskFzN7RZS7D113s=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    aipython3.python
+    protobuf3_21
+  ] ++ lib.optionals pythonSupport (with aipython3; [
+    pip
+    pythonOutputDistHook
+    setuptools
+    wheel
+  ]);
+
+  buildInputs = [
+    abseil-cpp
+    libpng
+    microsoft-gsl
+    nlohmann_json
+    nsync
+    re2
+    zlib
+  ] ++ lib.optionals pythonSupport [
+    aipython3.numpy
+    aipython3.pybind11
+    aipython3.packaging
+  ] ++ lib.optionals stdenv.isDarwin [
+    Foundation
+    iconv
+  ];
+
+  nativeCheckInputs = lib.optionals pythonSupport (with aipython3; [
+    gtest'
+    pytest
+    sympy
+    onnx-custom
+  ]);
+
+  # TODO: build server, and move .so's to lib output
+  # Python's wheel is stored in a separate dist output
+  outputs = [ "out" "dev" ] ++ lib.optionals pythonSupport [ "dist" ];
+
+  enableParallelBuilding = true;
+
+  cmakeDir = "../cmake";
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=RELEASE"
+    "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
+    "-DFETCHCONTENT_QUIET=OFF"
+    "-DFETCHCONTENT_SOURCE_DIR_ABSEIL_CPP=${abseil-cpp.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_DATE=${howard-hinnant-date}"
+    "-DFETCHCONTENT_SOURCE_DIR_EIGEN=${eigen}"
+    "-DFETCHCONTENT_SOURCE_DIR_FLATBUFFERS=${flatbuffers}"
+    "-DFETCHCONTENT_SOURCE_DIR_GOOGLE_NSYNC=${nsync.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_MP11=${mp11}"
+    "-DFETCHCONTENT_SOURCE_DIR_ONNX=${onnx-custom.src}"
+    "-DFETCHCONTENT_SOURCE_DIR_PYTORCH_CPUINFO=${pytorch_cpuinfo}"
+    "-DFETCHCONTENT_SOURCE_DIR_SAFEINT=${safeint}"
+    "-DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=ALWAYS"
+    "-Donnxruntime_BUILD_SHARED_LIB=ON"
+    "-Donnxruntime_BUILD_UNIT_TESTS=OFF"
+    "-Donnxruntime_ENABLE_LTO=ON"
+    "-Donnxruntime_USE_FULL_PROTOBUF=OFF"
+  ] ++ lib.optionals pythonSupport [
+    "-Donnxruntime_ENABLE_PYTHON=ON"
+  ];
+
+  doCheck = true;
+
+  postPatch = ''
+    substituteInPlace cmake/CMakeLists.txt \
+      --replace 'cmake_minimum_required(VERSION 3.26)' 'cmake_minimum_required(VERSION 3.25)'
+    substituteInPlace cmake/libonnxruntime.pc.cmake.in \
+      --replace '$'{prefix}/@CMAKE_INSTALL_ @CMAKE_INSTALL_
+  '' + lib.optionalString (stdenv.hostPlatform.system == "aarch64-linux") ''
+    # https://github.com/NixOS/nixpkgs/pull/226734#issuecomment-1663028691
+    rm -v onnxruntime/test/optimizer/nhwc_transformer_test.cc
+  '';
+
+  postBuild = lib.optionalString pythonSupport ''
+    python ../setup.py bdist_wheel
+  '';
+
+  postInstall = ''
+    # perform parts of `tools/ci_build/github/linux/copy_strip_binary.sh`
+    install -m644 -Dt $out/include \
+      ../include/onnxruntime/core/framework/provider_options.h \
+      ../include/onnxruntime/core/providers/cpu/cpu_provider_factory.h \
+      ../include/onnxruntime/core/session/onnxruntime_*.h
+  '';
+
+  passthru = {
+    protobuf = protobuf3_21;
+    tests = lib.optionalAttrs pythonSupport {
+      python = aipython3.onnxruntime;
+    };
+  };
+
+  meta = with lib; {
+    description = "Cross-platform, high performance scoring engine for ML models";
+    longDescription = ''
+      ONNX Runtime is a performance-focused complete scoring engine
+      for Open Neural Network Exchange (ONNX) models, with an open
+      extensible architecture to continually address the latest developments
+      in AI and Deep Learning. ONNX Runtime stays up to date with the ONNX
+      standard with complete implementation of all ONNX operators, and
+      supports all ONNX releases (1.2+) with both future and backwards
+      compatibility.
+    '';
+    homepage = "https://github.com/microsoft/onnxruntime";
+    changelog = "https://github.com/microsoft/onnxruntime/releases/tag/v${version}";
+    # https://github.com/microsoft/onnxruntime/blob/master/BUILD.md#architectures
+    platforms = platforms.unix;
+    license = licenses.mit;
+    maintainers = with maintainers; [ jonringer puffnfresh ck3d cbourjau ];
+  };
+}


### PR DESCRIPTION
Adds support for the [rembg](https://github.com/danielgatis/rembg) (automatic background remover) tool.

> Note: 
> - Only have linux pc available for testing. `onnxruntime` for example, has darwin-conditional dependencies
> - The example image should be added to blob as `rembg.webp`.

![rembg](https://github.com/nixified-ai/flake/assets/16964980/4030bbbc-f311-442c-bfaf-26732615993a)


