### PR TITLE
Fix invokeai after llama-cpp-python upgrade

### DIFF
--- a/packages/mediapipe/default.nix
+++ b/packages/mediapipe/default.nix
@@ -11,12 +11,12 @@
 
 buildPythonPackage {
   pname = "mediapipe";
-  version = "0.10.7";
+  version = "0.10.8";
   format = "wheel";
 
   src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/52/92/a2b0f9a943ebee88aa9dab040535ea05908ec102b8052b28c645cf0ac25b/mediapipe-0.10.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-    sha256 = "sha256-88kAkpxRn4Pj+Ib95WNj+53P36gHjpFt5rXlaX4bpco=";
+    url = "https://files.pythonhosted.org/packages/b9/9c/91262b3c43a4938fce2349ad0acd7463770604f4d964dfaabbd070761bb9/mediapipe-0.10.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+    sha256 = "sha256-K5u5w895+ISdtDwRk7XmIAp0BsjLVsBtyf8w2LCztbs=";
   };
 
   propagatedBuildInputs = [ protobuf numpy opencv4 matplotlib attrs ];
@@ -27,7 +27,7 @@ buildPythonPackage {
 
   meta = with lib; {
     description = "Cross-platform, customizable ML solutions for live and streaming media";
-    homepage = "https://github.com/google/mediapipe/releases/tag/v0.10.7";
+    homepage = "https://github.com/google/mediapipe/releases/tag/v0.10.8";
     license = licenses.asl20;
     maintainers = with maintainers; [ ];
   };

--- a/packages/starlette/default.nix
+++ b/packages/starlette/default.nix
@@ -6,6 +6,7 @@
 , aiofiles
 , anyio
 , contextlib2
+, hatchling
 , itsdangerous
 , jinja2
 , python-multipart
@@ -20,8 +21,8 @@
 
 buildPythonPackage rec {
   pname = "starlette";
-  version = "0.20.4";
-  format = "setuptools";
+  version = "0.22.0";
+  format = "pyproject";
 
   disabled = pythonOlder "3.6";
 
@@ -29,16 +30,8 @@ buildPythonPackage rec {
     owner = "encode";
     repo = pname;
     rev = "refs/tags/${version}";
-    hash = "sha256-vP2TJPn9lRGnLGkO8lUmnsoT6rSnhuWDD3WqNk76SM0=";
+    hash = "sha256-vyGLNQMCWu3zGFF7jRuozVLCqwR1zWBWuYTIDRBncHk=";
   };
-
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/encode/starlette/commit/ab70211f0e1fb7390668bf4891eeceda8d9723a0.diff";
-      excludes = [ "requirements.txt" ]; # conflicts
-      hash = "sha256-UHf4c4YUWp/1I1vD8J0hMewdlfkmluA+FyGf9ZsSv3Y=";
-    })
-  ];
 
   postPatch = ''
     # remove coverage arguments to pytest
@@ -48,6 +41,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     aiofiles
     anyio
+    hatchling
     itsdangerous
     jinja2
     python-multipart

--- a/projects/invokeai/package.nix
+++ b/projects/invokeai/package.nix
@@ -78,6 +78,8 @@ python3Packages.buildPythonPackage {
     dynamicprompts
     torchvision
     test-tube
+    onnx
+    onnxruntime
   ];
   nativeBuildInputs = with python3Packages; [ pythonRelaxDepsHook pip ];
   pythonRemoveDeps = [ "clip" "pyreadline3" "flaskwebgui" "opencv-python" "fastapi-socketio" ];


### PR DESCRIPTION
#65 broke invokeai, because the flake update switched to Python 3.11 and e.g. mediapipe fetched a 3.10 from pypi. textgen-nvidia and invokeai-nvidia build fine on my machine with this fix. Sorry that I did not test this properly in the first place. I also created #66 if you prefer to revert the llama-cpp-python upgrade.