### PR TITLE
Add path fixes for training and loading extensions

### DIFF
--- a/packages/datasets/default.nix
+++ b/packages/datasets/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "datasets";
+  version = "2.14.6";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-l+u6zo7HrxFDSofRIVN5kn+P7ivqssSmdAA3Vuz+kgw=";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "";
+    homepage = "";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/packages/peft/default.nix
+++ b/packages/peft/default.nix
@@ -9,18 +9,18 @@
 , torch
 , transformers
 , black
-, hf-doc-builder
+# , hf-doc-builder
 , ruff
 }:
 
 buildPythonPackage rec {
   pname = "peft";
-  version = "0.2.0";
+  version = "0.6.2";
   format = "pyproject";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-zjP0hMcDgZBwW2nk0iiSMMfBgZwQhHgUg6yOEY8Kca8=";
+    hash = "sha256-JE6pdo595J3EGwaNP5oyylCOMdQiNkBWZhZjO27RMx4=";
   };
 
   propagatedBuildInputs = [
@@ -36,11 +36,11 @@ buildPythonPackage rec {
   passthru.optional-dependencies = {
     dev = [
       black
-      hf-doc-builder
+      # hf-doc-builder
       ruff
     ];
     docs_specific = [
-      hf-doc-builder
+      # hf-doc-builder
     ];
     quality = [
       black

--- a/packages/sentence-transformers/default.nix
+++ b/packages/sentence-transformers/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "sentence-transformers";
+  version = "2.2.2";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-28YBY7J94hB2yaMNJLW3tvoFFB1ozyVT+pp3v3mikTY=";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "";
+    homepage = "";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/packages/speechrecognition/default.nix
+++ b/packages/speechrecognition/default.nix
@@ -1,0 +1,25 @@
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "speechrecognition";
+  version = "3.10.4";
+  format = "setuptools";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "sha256-mGuvz2HxRiXC886mpHGDjt03ntaK7te488D7QeIfESU=";
+  };
+
+  # Wants to run tests using a real audio device
+  doCheck = false;
+
+  meta = with lib; {
+    description = "";
+    homepage = "";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/packages/tokenizers/default.nix
+++ b/packages/tokenizers/default.nix
@@ -1,0 +1,24 @@
+{ lib
+, buildPythonPackage
+, fetchurl
+}:
+
+buildPythonPackage rec {
+  pname = "tokenizers";
+  version = "0.14.1";
+  format = "wheel";
+
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/a7/7b/c1f643eb086b6c5c33eef0c3752e37624bd23e4cbc9f1332748f1c6252d1/tokenizers-0.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+    sha256 = "sha256-YP7DgHeNdcu0kvFMqXTxHze0HVPAV7nIuiEzFbhuH4Q=";
+  };
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "";
+    homepage = "";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/projects/textgen/default.nix
+++ b/projects/textgen/default.nix
@@ -10,25 +10,32 @@ in
     commonOverlays = [
       overlays.python-fixPackages
       (l.overlays.callManyPackages [
+        ../../packages/accelerate
+        ../../packages/analytics-python
         ../../packages/apispec-webframeworks
-        ../../packages/torch-grammar
+        ../../packages/autogptq
+        # https://github.com/huggingface/datasets/issues/6352#issuecomment-1781073234
+        ../../packages/datasets
+        ../../packages/ffmpy
         ../../packages/flexgen
         ../../packages/gradio
         ../../packages/gradio-client
-        ../../packages/analytics-python
-        ../../packages/ffmpy
         ../../packages/llama-cpp-python
-        ../../packages/rwkv
-        ../../packages/autogptq
+        ../../packages/peft
         ../../packages/rouge
+        ../../packages/rwkv
+        ../../packages/sentence-transformers
+        ../../packages/speechrecognition
+        ../../packages/tokenizers
+        ../../packages/torch-grammar
       ])
     ];
 
     python3Variants = {
-      amd = l.overlays.applyOverlays pkgs.python3Packages (commonOverlays ++ [
+      amd = l.overlays.applyOverlays pkgs.python310Packages (commonOverlays ++ [
         overlays.python-torchRocm
       ]);
-      nvidia = l.overlays.applyOverlays pkgs.python3Packages (commonOverlays ++ [
+      nvidia = l.overlays.applyOverlays pkgs.python310Packages (commonOverlays ++ [
         overlays.python-torchCuda
         overlays.python-bitsAndBytesOldGpu
       ]);


### PR DESCRIPTION
- Fixes various paths that are hardcoded upstream
- Switches to Python 3.10 because torch.compile doesn't support 3.11+
- Adds dependencies necessary for openai extension to work