### PR TITLE
fetchers/fetchresource: Newer curl version requires netrc file to be found

### DIFF
--- a/flake-modules/fetchers/fetchresource/default.nix
+++ b/flake-modules/fetchers/fetchresource/default.nix
@@ -7,6 +7,9 @@
   curlOpts = "-H @/build/ACTIVE_TOKEN";
   netrcImpureEnvVars = [ "HF_TOKEN" "CIVITAI_API_TOKEN" ];
   netrcPhase = ''
+    # Workaround for newer curl versions to prevent crashing due to non-existent netrc file
+    touch /build/netrc
+
     # Warn if HF_TOKEN or CIVITAI_API_TOKEN are not set or didn't work, in
     # the case of failure to fetch
     warnEmptyTokensHook() {


### PR DESCRIPTION
Newer curl versions will require the netrc file to be found if called with the --netrc-file argument

See also: https://github.com/NixOS/nixpkgs/issues/389194#issuecomment-2718591739