### PR TITLE
Update comfyui + comfyui-gguf

### DIFF
--- a/flake-modules/projects/comfyui/pkgs/comfyui-gguf/package.nix
+++ b/flake-modules/projects/comfyui/pkgs/comfyui-gguf/package.nix
@@ -5,7 +5,7 @@
 }:
 comfyuiPackages.comfyui.mkComfyUICustomNode {
   pname = "comfyui-gguf";
-  version = "unstable-2025-06-15";
+  version = "unstable-2025-09-14";
   propagatedBuildInputs = with python3Packages; [
     gguf
     sentencepiece
@@ -14,7 +14,7 @@ comfyuiPackages.comfyui.mkComfyUICustomNode {
   src = fetchFromGitHub {
     owner = "city96";
     repo = "ComfyUI-GGUF";
-    rev = "b3ec875a68d94b758914fd48d30571d953bb7a54";
-    hash = "sha256-DdCZnRtx9svz9aNxS+HJORNYsDoWVI9DWLcMocRT268=";
+    rev = "be2a08330d7ec232d684e50ab938870d7529471e";
+    hash = "sha256-NtpoLwlcMXeVCffZmQeHKDl9hM6gCBprdnhHblrWQ20=";
   };
 }

--- a/flake-modules/projects/comfyui/pkgs/comfyui-unwrapped/package.nix
+++ b/flake-modules/projects/comfyui/pkgs/comfyui-unwrapped/package.nix
@@ -16,13 +16,13 @@ let
 in
 python3Packages.buildPythonApplication rec {
   pname = "comfyui";
-  version = "unstable-2025-09-06";
+  version = "0.3.62";
 
   src = fetchFromGitHub {
     owner = "comfyanonymous";
     repo = "ComfyUI";
-    rev = "ea6cdd2631fbca6ed81b95796150c32c9a029f0d";
-    hash = "sha256-DEM+6NCvUVwBkD2Jtb7WVEVVc3tyCaUc383DXPLN9Mg=";
+    rev = "bab8ba20bf47d985d6b1d73627c2add76bd4e716";
+    hash = "sha256-X2lvOJR6GMhUME/ADhNRMpGAo7EtG60h+Q1imC10LBM=";
   };
 
   patches = [


### PR DESCRIPTION
This updates comfyui to 0.3.62 (needed for a qwen image-related node) and comfyui-gguf to 2025-09-14 (needed for qwen gguf models).