### PR TITLE
comfyui-res4lyf: Don't put the config file in the Nix store

### DIFF
--- a/flake-modules/projects/comfyui/pkgs/comfyui-res4lyf/config.patch
+++ b/flake-modules/projects/comfyui/pkgs/comfyui-res4lyf/config.patch
@@ -1,0 +1,30 @@
+diff --git a/res4lyf.py b/res4lyf.py
+index 7344611..69dfde1 100644
+--- a/res4lyf.py
++++ b/res4lyf.py
+@@ -12,6 +12,7 @@ import comfy.samplers
+ from aiohttp import web
+ from server import PromptServer
+ from tqdm import tqdm
++import folder_paths
+ 
+ 
+ CONFIG_FILE_NAME = "res4lyf.config.json"
+@@ -168,7 +169,7 @@ def RESplain(*args, debug='info'):
+         print(f"({name} {type}) {message}")
+ 
+ def get_ext_dir(subpath=None, mkdir=False):
+-    dir = os.path.dirname(__file__)
++    dir = folder_paths.get_user_directory()
+     if subpath is not None:
+         dir = os.path.join(dir, subpath)
+ 
+@@ -192,7 +193,7 @@ def get_extension_config(reload=False):
+         return config
+ 
+     config_path = get_ext_dir(CONFIG_FILE_NAME)
+-    default_config_path = get_ext_dir(DEFAULT_CONFIG_FILE_NAME)
++    default_config_path = os.path.join(os.path.dirname(__file__), DEFAULT_CONFIG_FILE_NAME)
+     
+     if os.path.exists(default_config_path):
+         with open(default_config_path, "r") as f:

--- a/flake-modules/projects/comfyui/pkgs/comfyui-res4lyf/package.nix
+++ b/flake-modules/projects/comfyui/pkgs/comfyui-res4lyf/package.nix
@@ -15,6 +15,8 @@ comfyuiPackages.comfyui.mkComfyUICustomNode rec {
     hash = "sha256-ZVTXEP7TGXat+JmaJCVd/LS+F+Dx9WUo2m0FoJ4WRO0=";
   };
 
+  patches = [ ./config.patch ];
+
   # pyproject = false;
   propagatedBuildInputs = with python3Packages; [
     opencv-python


### PR DESCRIPTION
This fixes the startup error:
```
  File "/nix/store/19434bkhhqq3w3spnw4xz8wh49pnlffq-comfyui-wrapped/lib/python3.13/site-packages/custom_nodes/comfyui-res4lyf/res4lyf.py", line 205, in get_extension_config
    with open(config_path, "w") as f:
         ~~~~^^^^^^^^^^^^^^^^^^
OSError: [Errno 30] Read-only file system: '/nix/store/19434bkhhqq3w3spnw4xz8wh49pnlffq-comfyui-wrapped/lib/python3.13/site-packages/custom_nodes/comfyui-res4lyf/res4lyf.config.json'

Cannot import /nix/store/19434bkhhqq3w3spnw4xz8wh49pnlffq-comfyui-wrapped/lib/python3.13/site-packages/custom_nodes/comfyui-res4lyf module for custom nodes: [Errno 30] Read-only file system: '/nix/store/19434bkhhqq3w3spnw4xz8wh49pnlffq-comfyui-wrapped/lib/python3.13/site-packages/custom_nodes/comfyui-res4lyf/res4lyf.config.json'
```

The new location for the config file is `~/.local/share/comfyui/user/res4lyf.config.json`.

Fixes #126.