### PR TITLE
fix fetchair model naming

### DIFF
--- a/flake-modules/fetchers/fetchair/fetcher.nix
+++ b/flake-modules/fetchers/fetchair/fetcher.nix
@@ -71,9 +71,8 @@ let
 
   fetchArgs = (
     {
-      name = "model";
+      inherit name url sha256;
       passthru.name = name;
-      inherit url sha256;
     }
     // (if args ? passthru then { inherit (args) passthru; } else { })
   );


### PR DESCRIPTION
This fixes the issue described in #147 . It is a simple fix that just involves passing the `name` parameter given to the `fetchair` function to the underlying call to `fetchResource`.