### PR TITLE
Fix fetchair model naming

### DIFF
--- a/flake-modules/fetchers/fetchair/fetcher.nix
+++ b/flake-modules/fetchers/fetchair/fetcher.nix
@@ -69,14 +69,14 @@ let
     else
       lib.throw "support for constructing URL from AIR with ${parsed.source} as source has not been added yet";
 
-  fetchArgs = (
-    {
-      name = "model";
-      passthru.name = name;
-      inherit url sha256;
+  fetchArgs = {
+    name = "model";
+    passthru = {
+      inherit name;
     }
-    // (if args ? passthru then { inherit (args) passthru; } else { })
-  );
+    // (if args ? passthru then args.passthru else { });
+    inherit url sha256;
+  };
   metaAttr = {
     meta = {
       inherit air;


### PR DESCRIPTION
Renaming the branch in my fork closed #148. Reopening with the new branch.

This fixes the issue described in https://github.com/nixified-ai/flake/issues/147 . It is a simple fix that just involves passing the name parameter given to the fetchair function to the underlying call to fetchResource.