### PR TITLE
Update hercules-ci-effects and switch to reset baseMerge method

### DIFF
--- a/flake-modules/projects/comfyui/ci.nix
+++ b/flake-modules/projects/comfyui/ci.nix
@@ -23,7 +23,7 @@ toplevel@{ inputs, withSystem, ... }:
               git.checkout.forgeType = config.repo.forgeType;
               git.update.branch = "automation/comfyui-${lib.replaceString " " "-" description}";
               git.update.baseMerge.enable = true;
-              git.update.baseMerge.method = "rebase";
+              git.update.baseMerge.method = "reset";
               git.update.pullRequest.enable = true;
               git.update.pullRequest.title = title;
               git.update.pullRequest.body = "";

--- a/flake.lock
+++ b/flake.lock
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1765774562,
+        "lastModified": 1768176000,
         "narHash": "sha256-UQhfCggNGDc7eam+EittlYmeW89CZVT1KkFIHZWBH7k=",
         "owner": "hercules-ci",
         "repo": "hercules-ci-effects",
-        "rev": "edcbb19948b6caf1700434e369fde6ff9e6a3c93",
+        "rev": "7674575b71d317799ee2c3d1703144d885eb3ea3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the `hercules-ci-effects` flake input to include the changes from PR #203. Updates the git-update effect configuration in `flake-modules/projects/comfyui/ci.nix` to use `git.update.baseMerge.method = "reset"`.