### PR TITLE
feat: add comfyui-crystools custom node

### DIFF
--- a/flake-modules/projects/comfyui/customNodes-npins/sources.json
+++ b/flake-modules/projects/comfyui/customNodes-npins/sources.json
@@ -146,6 +146,19 @@
       "url": "https://github.com/Fannovel16/comfyui_controlnet_aux/archive/e8b689a513c3e6b63edc44066560ca5919c0576e.tar.gz",
       "hash": "sha256-tMmERf4y7sfuEGao7JHC7FLjBgPuViCtHxr8f9NnHzo="
     },
+    "comfyui-crystools": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "crystian",
+        "repo": "ComfyUI-Crystools"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "2f18256c5b5063937106f29a8e0a7db3ae3869b7",
+      "url": "https://github.com/crystian/ComfyUI-Crystools/archive/2f18256c5b5063937106f29a8e0a7db3ae3869b7.tar.gz",
+      "hash": "sha256-IvLgvudqJV6QeNxwA3HbIlGxShCfUBBSZ8DSjOVlSyE="
+    },
     "comfyui-easy-use": {
       "type": "Git",
       "repository": {

--- a/flake-modules/projects/comfyui/customNodes/comfyui-crystools/css-path.patch
+++ b/flake-modules/projects/comfyui/customNodes/comfyui-crystools/css-path.patch
@@ -1,0 +1,11 @@
+diff --git a/web/styles.js b/web/styles.js
+index 843268d..d6d073a 100644
+--- a/web/styles.js
++++ b/web/styles.js
+@@ -1,5 +1,5 @@
+ import { utils } from './comfy/index.js';
+-utils.addStylesheet('extensions/ComfyUI-Crystools/monitor.css');
++utils.addStylesheet('extensions/comfyui-crystools/monitor.css');
+ export var Styles;
+ (function (Styles) {
+     Styles["BARS"] = "BARS";

--- a/flake-modules/projects/comfyui/customNodes/comfyui-crystools/package.nix
+++ b/flake-modules/projects/comfyui/customNodes/comfyui-crystools/package.nix
@@ -1,0 +1,14 @@
+{
+  python3Packages,
+}:
+{
+  propagatedBuildInputs = with python3Packages; [
+    deepdiff
+    nvidia-ml-py
+    py-cpuinfo
+    piexif
+  ];
+  patches = [
+    ./css-path.patch
+  ];
+}


### PR DESCRIPTION
# Add comfyui-crystools custom node

https://github.com/crystian/ComfyUI-Crystools — a resource monitor (CPU/GPU/RAM/VRAM/temp/disk) and debugger toolkit for ComfyUI, with progress bar, metadata comparator, JSON diff, and pipe primitives.

<img width="534" height="79" alt="image" src="https://github.com/user-attachments/assets/851b2c7f-9557-4463-a3de-8929b63903b9" />


## Changes

- customNodes-npins/sources.json — add pin entry for comfyui-crystools
- customNodes/comfyui-crystools/package.nix — python deps + patch
- customNodes/comfyui-crystools/patches/css-path.patch — fix monitor.css 404 caused by uppercase path
 
## Why the patch

ComfyUI serves extension static files at a lowercase URL path derived from the directory name (e.g. extensions/comfyui-crystools/monitor.css), but the upstream source hardcodes extensions/ComfyUI-Crystools/monitor.css (uppercase C). This causes a 404 in browsers, leaving the resource monitors completely unstyled.
The upstream maintainer reverted the lowercase fix on main because their installation uses an uppercase directory name. In the Nix build the pname is lowercase, so the mismatch persists.

## Python dependencies

- deepdiff
- nvidia-ml-py
- py-cpuinfo
- piexif
