### PR TITLE
feat: add comfyui-ultimatesdupscale custom node; pass fetchSubmodules in nodePropsFromNpinSource

### DIFF
--- a/flake-modules/projects/comfyui/customNodes-npins/sources.json
+++ b/flake-modules/projects/comfyui/customNodes-npins/sources.json
@@ -458,6 +458,19 @@
       "url": "https://github.com/shiimizu/ComfyUI-TiledDiffusion/archive/a155b1bac39147381aeaa52b9be42e545626a44f.tar.gz",
       "hash": "sha256-UDcjTWyA2kQKyeX5pZuvX0RnVAz56WCbak0JGSy4w0Y="
     },
+    "comfyui-ultimatesdupscale": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "ssitu",
+        "repo": "ComfyUI_UltimateSDUpscale"
+      },
+      "branch": "main",
+      "submodules": true,
+      "revision": "bebd5696fddd61cb0d08949a222c508898ab5577",
+      "url": "https://github.com/ssitu/ComfyUI_UltimateSDUpscale/archive/bebd5696fddd61cb0d08949a222c508898ab5577.tar.gz",
+      "hash": "sha256-U1C0baJocG8HvKqhhgVj9TdO2yccfdG5wNMHFaxlfyI="
+    },
     "comfyui-unload-model": {
       "type": "Git",
       "repository": {

--- a/flake-modules/projects/comfyui/lib.nix
+++ b/flake-modules/projects/comfyui/lib.nix
@@ -81,6 +81,7 @@ rec {
         owner = source.repository.owner;
         sha256 = source.hash;
         rev = source.revision;
+        fetchSubmodules = source.submodules or false;
       };
     };
 }


### PR DESCRIPTION
Add comfyui-ultimatesdupscale custom node
https://github.com/ssitu/ComfyUI_UltimateSDUpscale — ComfyUI nodes for the Ultimate SD Upscale script.
Changes
- customNodes-npins/sources.json — add pin with submodules: true
- lib.nix — pass fetchSubmodules through nodePropsFromNpinSource
  (previously ignored; needed by repos with git submodules)
Submodule
Uses Coyote-A/ultimate-upscale-for-automatic1111 as a git submodule
at repositories/ultimate_sd_upscale.
