### PR TITLE
fix(comfy-kitchen): replace `lib.optional` with `lib.optionals` to resolve Nixpkgs 26.05 deprecation warning

### DIFF
--- a/flake-modules/projects/comfyui/pkgs/comfy-kitchen/package.nix
+++ b/flake-modules/projects/comfyui/pkgs/comfy-kitchen/package.nix
@@ -36,7 +36,7 @@ python3Packages.callPackage (
       nanobind
     ] ++ lib.optional cudaSupport cudaPackages.cuda_nvcc;
 
-    buildInputs = lib.optional cudaSupport [
+    buildInputs = lib.optionals cudaSupport [
       cudaPackages.cuda_cudart
       cudaPackages.libcublas
     ];


### PR DESCRIPTION
## Summary

Fixes a nested list in `buildInputs` that triggers a deprecation warning in Nixpkgs release 26.05.

## Problem

When `cudaSupport` is enabled, the `comfy-kitchen` package's `buildInputs` uses `lib.optional` with a list argument, producing a nested list:

```nix
buildInputs = lib.optional cudaSupport [
  cudaPackages.cuda_cudart
  cudaPackages.libcublas
];
```

When `cudaSupport = true`, this evaluates to `[[cuda_cudart, libcublas]]` — a nested list. Nixpkgs 26.05 now emits:

```
evaluation warning: Dependency of package 'python3.13-comfy-kitchen-0.2.10' uses a nested list in attribute 'buildInputs'.
This is deprecated as of Nixpkgs release 26.05, and support will be removed in a future nixpkgs release.
```

## Solution

Change `lib.optional` to `lib.optionals` (note the plural `s`), which returns the list elements directly instead of wrapping them in another list:

```nix
buildInputs = lib.optionals cudaSupport [
  cudaPackages.cuda_cudart
  cudaPackages.libcublas
];
```

Now evaluates to `[cuda_cudart, libcublas]` — a flat list, as expected.

## Changes

| File | Change |
|------|--------|
| `flake-modules/projects/comfyui/pkgs/comfy-kitchen/package.nix` | Line 39: `lib.optional` → `lib.optionals` |

## Verification

- [x] The change is a single-character fix with no functional impact on build outputs
- [x] No other files in the repo exhibit the same `lib.optional [...]` pattern
- [x] Downstream `comfyui-unwrapped` dependency is unaffected (uses `lib.optional config.cudaSupport comfy-kitchen` with a single element, which is correct)

## Impact

- **Build behavior**: Unchanged — nixpkgs flattens nested lists internally, so the resolved dependency set is identical
- **Deprecation warning**: Eliminated
- **Future compatibility**: Restores compatibility with upcoming nixpkgs releases where nested `buildInputs` support will be removed