### PR TITLE
fix(comfy-kitchen): replace lib.optional with lib.optionals to resolve Nixpkgs 26.05 deprecation warning (REBASED ON MASTER)

### DIFF
--- a/flake-modules/projects/comfyui/pkgs/comfy-kitchen/package.nix
+++ b/flake-modules/projects/comfyui/pkgs/comfy-kitchen/package.nix
@@ -36,7 +36,7 @@ python3Packages.callPackage (
       nanobind
     ] ++ lib.optional cudaSupport cudaPackages.cuda_nvcc;
 
-    buildInputs = lib.optional cudaSupport [
+    buildInputs = lib.optionals cudaSupport [
       cudaPackages.cuda_cudart
       cudaPackages.libcublas
     ];


### PR DESCRIPTION
Copy of https://github.com/nixified-ai/flake/pull/318
Rebased on master. Branch created in main repo to trigger CI